### PR TITLE
Updated .grcat regex for red colour

### DIFF
--- a/.grcat
+++ b/.grcat
@@ -4,7 +4,7 @@ count=stop
 colours=white
 -
 #table borders
-regexp=[+\-|]+
+regexp=[+\-]+[+\-]|[|]
 colours=red
 -
 #default word color


### PR DESCRIPTION
Corrected regex for colour red: i had records of type XXXXX-X and - in the records was colored as well.
