### PR TITLE
Improved regex for numeric values

### DIFF
--- a/.grcat
+++ b/.grcat
@@ -15,7 +15,7 @@ colours=white
 -
 
 #numeric
-regexp=\s[\d\.]+(\s|.$)
+regexp=\s[\d\.]+\s*($|(?=\|))
 colours=yellow
 -
 


### PR DESCRIPTION
Just noticed that if a text contains numeric values they get colored as if they where alone.
Also, I implemented a wrapper for grcat for fault tolerance check if you want the last commits of https://github.com/jpducassou/dotfiles.
Nice job by the way.
Kind regards,
JP
